### PR TITLE
create results directory if not existing

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -3,9 +3,6 @@ import csv
 import warnings
 import sys
 
-#from snakemake_wrapper_utils.java import get_java_opts
-# =concat("lungControl",right(B2,LEN(B2)-len(left(B2,12))))
-
 configfile: "snakemake_config.yaml"
 
 # Ensure the results directory is made

--- a/Snakefile
+++ b/Snakefile
@@ -8,6 +8,10 @@ import sys
 
 configfile: "snakemake_config.yaml"
 
+# Ensure the results directory is made
+os.makedirs(config["ROOTDIR"], exist_ok=True)
+
+
 # Validate users are using conda. This is important for temporary conda environments defined in the workflow
 if not workflow.use_conda:
     sys.stderr.write("\nYou are not using conda. Pass the '--use-conda' flag to snakemake.\nExample: snakemake --cores 10 --use-conda\n\n")
@@ -1218,4 +1222,3 @@ rule multiqc:
             rm *.fastq
         fi
         """
-


### PR DESCRIPTION
This creates the `config["ROOTDIR"]` folder in one of the first lines of the workflow.

This should alleviate #8 