### PR TITLE
Lock tabulate to version 0.8.10

### DIFF
--- a/docs/pages/fastq/fastq_setup_conda.md
+++ b/docs/pages/fastq/fastq_setup_conda.md
@@ -68,7 +68,7 @@ module load mamba
 ### Install Snakemake
 Snakemake is required to run the pipeline.
 ```bash
-mamba install --name snakemake --channel bioconda snakemake==6.15.5
+mamba install --name snakemake --channel bioconda snakemake==6.15.5 tabulate==0.8.10
 ```
 
 |      Component       |                      Description                      |


### PR DESCRIPTION
Using a tabulate version newer than `0.8.10` has issues with Snakemake. In the documentation during snakemake installation, set tabulate to `0.8.10`