### PR TITLE
Fix default scratch directory

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,7 @@
 
 # Modify these settings to reflect your paths
 # Only change values after the colon (':')
+SCRATCH_DIR: "/tmp"
 MASTER_CONTROL: "controls/master_control.csv"  # csv with srr, rename, layout
 ROOTDIR: "results" # redirect output root directory
 DUMP_FASTQ_FILES: "results/dump_fastq_input" # downloaded fastq output file location


### PR DESCRIPTION
This pull request adds a new `config.yaml` variable, `SCRATCH_DIR`, which defines the location where scratch files should be saved

Created to fix #60 