### PR TITLE
Automatically determine delimiter in input control files

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -14,8 +14,12 @@ if validate.validate(config=config):
     print("Control file valid! Continuing...")
 
 os.makedirs(config["ROOTDIR"], exist_ok=True)
+
+# Get the delimiter from the master control file; from: https://stackoverflow.com/questions/16312104
+dialect = csv.Sniffer().sniff(open(config["MASTER_CONTROL"]).read(1024))
 samples: pd.DataFrame = pd.read_csv(
     config["MASTER_CONTROL"],
+    delimiter=str(dialect.delimiter),
     names=["srr", "sample", "endtype", "prep_method"]
 )
 config_file_basename=os.path.basename(config["MASTER_CONTROL"]).split(".")[0]

--- a/utils/get.py
+++ b/utils/get.py
@@ -20,8 +20,10 @@ def from_master_config(config: dict, attribute: str) -> list[str]:
         if index_value >= 2:
             index_value -= 1
 
-        control_lines = open(config["MASTER_CONTROL"], "r").readlines()
-        reader = csv.reader(control_lines)
+        control_lines = open(config["MASTER_CONTROL"], "r")
+        dialect = csv.Sniffer().sniff(control_lines.read(1024))
+        control_lines.seek(0)
+        reader = csv.reader(control_lines, delimiter=str(dialect.delimiter))
 
         for line in reader:
 
@@ -57,6 +59,7 @@ def from_master_config(config: dict, attribute: str) -> list[str]:
 
             collect_attributes += target_attribute
 
+        control_lines.close()
         return collect_attributes
 
 

--- a/utils/validate.py
+++ b/utils/validate.py
@@ -59,7 +59,9 @@ class _ControlData:
         schema: dict[str, dict[str, list[str]]] = {}
     
         with open(control, "r") as i_stream:
-            reader = csv.reader(i_stream)
+            dialect = csv.Sniffer().sniff(i_stream.read(1024))
+            i_stream.seek(0)
+            reader = csv.reader(i_stream, delimiter=str(dialect.delimiter))
             for line in reader:
                 sample = line[1]  # "naiveB_S1R1"
                 cell_type = sample.split("_")[0]  # naiveB

--- a/utils/validate.py
+++ b/utils/validate.py
@@ -129,3 +129,15 @@ def validate(config: dict) -> bool:
             genome_valid = False
     
     return control_valid and genome_valid
+
+
+if __name__ == '__main__':
+    comma_file = "test_data/comma_sep.txt"
+    tab_file = "test_data/tab_sep.txt"
+    
+    comma_schema = _ControlData.ingest(comma_file)
+    tab_schema = _ControlData.ingest(tab_file)
+    
+    print(comma_schema)
+    print(tab_schema)
+    


### PR DESCRIPTION
This feature uses python's [`csv.Sniffer()`](https://docs.python.org/3/library/csv.html#csv.Sniffer) class to automatically determine the delimiter used in the input control files